### PR TITLE
obs-ffmpeg: Do not enable hardware decoding by default

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -93,9 +93,6 @@ static void ffmpeg_source_defaults(obs_data_t *settings)
 	obs_data_set_default_bool(settings, "looping", false);
 	obs_data_set_default_bool(settings, "clear_on_media_end", true);
 	obs_data_set_default_bool(settings, "restart_on_activate", true);
-#if defined(_WIN32)
-	obs_data_set_default_bool(settings, "hw_decode", true);
-#endif
 	obs_data_set_default_int(settings, "buffering_mb", 2);
 	obs_data_set_default_int(settings, "speed_percent", 100);
 }


### PR DESCRIPTION
If a user has a tremendous amount of media files, this can cause
instability.  Instead, make hardware decoding something the user has to
explicitly enable.

Although hardware decoding was technically enabled by default even
before we fixed it, fixing it was essentially a change to defaults for
users because it was just not even available before version 24.